### PR TITLE
Makes <!> external and declares arity.

### DIFF
--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -92,7 +92,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.c#34;
    string->n 1 string->symbol 1 string? 1 subst 3 sum 1 symbol? 1 systemf 1 tail 1 tl 1 tc 1 tc? 0 
    thaw 1 tlstr 1 track 1 trap-error 2 tuple? 1 type 2 return 3 undefmacro 1 unput 3 unprofile 1 unify 4 unify! 4 
    union 2 untrack 1 unspecialise 1 undefmacro 1 vector 1 vector-> 3 value 1 variable? 1 version 0  
-   write-byte 2 write-to-file 2 y-or-n? 1 + 2 * 2 / 2 - 2 == 2 <e> 1 @p 2 @v 2 @s 2 preclude 1 include 1 
+   write-byte 2 write-to-file 2 y-or-n? 1 + 2 * 2 / 2 - 2 == 2 <e> 1 <!> 1 @p 2 @v 2 @s 2 preclude 1 include 1 
    preclude-all-but 1 include-all-but 1])
 
 (define systemf
@@ -107,7 +107,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.c#34;
 (put (intern "shen") external-symbols
      [! } { --> <-- && : ; :- := _ *language* *implementation* *stinput* *stoutput* *home-directory* *version* 
       *maximum-print-sequence-size* *macros* *os* *release* *property-vector* @v @p @s *port* *porters* *hush*
-      <- -> <e> == = >= > /. =! $ - / * + <= < >> <> y-or-n? write-to-file write-byte where when warn version                   
+      <- -> <e> <!> == = >= > /. =! $ - / * + <= < >> <> y-or-n? write-to-file write-byte where when warn version                   
       verified variable? value vector-> <-vector vector vector? unspecialise untrack unit unix union unify 
       unify! unput unprofile undefmacro return type tuple? true trap-error track time thaw tc? tc tl tlstr tlv 
       tail systemf synonyms symbol symbol? string->symbol sum subst string? string->n stream string stinput 

--- a/sources/make.shen
+++ b/sources/make.shen
@@ -9,6 +9,7 @@
 \\(systemf package?)
 (systemf internal)
 (systemf receive)
+(systemf <!>)
 
 (define make
   -> (map (function make-file) ["core.shen" "declarations.shen" "load.shen" "macros.shen"


### PR DESCRIPTION
This fixes the issue of having to write `shen.<!>` instead of just `<!>` in defcc declarations.

The arity declaration is not necessary for the fix, but doesn't hurt.