### PR TITLE
Release 19.3

### DIFF
--- a/bugfixes.txt
+++ b/bugfixes.txt
@@ -193,3 +193,10 @@ Shen 19.2
 receive made external
 callfailure in shen.next-50 corrected
 
+Shen 19.3
+
+Fixed prolog tests
+Fixed untrack function
+Made <!> external and declared arity
+*home-directory* is not set anymore if it already has a value
+

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -66,7 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.c#34;
 (set *infs* 0)
 (set *hush* false)
 (set *optimise* false)
-(set *version* "Shen 19.2")
+(set *version* "Shen 19.3")
 
 (define initialise_arity_table
   [] -> []


### PR DESCRIPTION
This includes the changes we have introduced so far (all small bugfixes). I want to tag this as a release before doing whitespace cleanup so that we have an usefull diff between releases (and probably migrating from `bugfixes.txt` to a `CHANGELOG` file with a more traditional format with newer changes at the top).

I suppose 19.4 can be the "formatting and cleanup" release of which diff can just be skipped by everyone wanting to see how the code changed. 