### PR TITLE
Added error-to-string to intialise_arity_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [Unreleased]
+
+### Fixed
+- Added `error-to-string` to `initialise_arity_table`.
+
 ## [19.3.1] - 2017-02-19
 
 ### Added

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -98,7 +98,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  [abort 0 absvector? 1 absvector 1 adjoin 2 and 2 append 2 arity 1
   assoc 2 boolean? 1 cd 1 compile 3 concat 2 cons 2 cons? 1
   cn 2 declare 2 destroy 1 difference 2 do 2 element? 2 empty? 1
-  enable-type-theory 1 interror 2 eval 1
+  enable-type-theory 1 error-to-string 1 interror 2 eval 1
   eval-kl 1 explode 1 external 1 fail-if 2 fail 0 fix 2
   findall 5 freeze 1 fst 1 gensym 1 get 3
   get-time 1 address-> 3 <-address 2 <-vector 2 > 2 >= 2 = 2


### PR DESCRIPTION
I noticed `(function error-to-string)` wasn't working ("error-to-string has no lambda expansion") and attempted a fix.

Should anything else be done for `error-to-string` or is this good?