### PR TITLE
Added str and vector? to initialise_arity_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 
 ### Fixed
-- Added `error-to-string` to `initialise_arity_table`.
+- Added to `initialise_arity_table`:
+  - `bound?`
+  - `close`
+  - `error-to-string`
+  - `ln`
+  - `limit`
+  - `open`
+  - `str`
+  - `vector?`
 
 ## [19.3.1] - 2017-02-19
 

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -115,12 +115,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   read 1 read-byte 1 read-from-string 1
   receive 1 release 0 remove 2 require 3 reverse 1 set 2
   simple-error 1 snd 1 specialise 1 spy 1 step 1 stinput 0 stoutput 0
-  string->n 1 string->symbol 1 string? 1 subst 3 sum 1
+  string->n 1 string->symbol 1 string? 1 str 1 subst 3 sum 1
   symbol? 1 systemf 1 tail 1 tl 1 tc 1 tc? 0
   thaw 1 tlstr 1 track 1 trap-error 2 tuple? 1 type 2
   return 3 undefmacro 1 unput 3 unprofile 1 unify 4 unify! 4
   union 2 untrack 1 unspecialise 1 undefmacro 1
-  vector 1 vector-> 3 value 1 variable? 1 version 0
+  vector 1 vector? 1 vector-> 3 value 1 variable? 1 version 0
   write-byte 2 write-to-file 2 y-or-n? 1 + 2 * 2 / 2 - 2 == 2
   <e> 1 <!> 1 @p 2 @v 2 @s 2 preclude 1 include 1
   preclude-all-but 1 include-all-but 1])

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -96,7 +96,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (initialise_arity_table
  [abort 0 absvector? 1 absvector 1 adjoin 2 and 2 append 2 arity 1
-  assoc 2 boolean? 1 cd 1 compile 3 concat 2 cons 2 cons? 1
+  assoc 2 boolean? 1 cd 1 close 1 compile 3 concat 2 cons 2 cons? 1
   cn 2 declare 2 destroy 1 difference 2 do 2 element? 2 empty? 1
   enable-type-theory 1 error-to-string 1 interror 2 eval 1
   eval-kl 1 explode 1 external 1 fail-if 2 fail 0 fix 2
@@ -108,7 +108,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   length 1 lineread 1 load 1 < 2 <= 2 vector 1 macroexpand 1 map 2
   mapcan 2 maxinferences 1 not 1 nth 2
   n->string 1 number? 1 occurs-check 1 occurrences 2 occurs-check 1
-  optimise 1 or 2 os 0 package 3 package? 1
+  open 2 optimise 1 or 2 os 0 package 3 package? 1
   port 0 porters 0 pos 2 print 1 profile 1 profile-results 1 pr 2
   ps 1 preclude 1 preclude-all-but 1 protect 1
   address-> 3 put 4 reassemble 2 read-file-as-string 1 read-file 1

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -96,7 +96,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (initialise_arity_table
  [abort 0 absvector? 1 absvector 1 adjoin 2 and 2 append 2 arity 1
-  assoc 2 boolean? 1 cd 1 close 1 compile 3 concat 2 cons 2 cons? 1
+  assoc 2 boolean? 1 bound? 1 cd 1 close 1 compile 3 concat 2 cons 2 cons? 1
   cn 2 declare 2 destroy 1 difference 2 do 2 element? 2 empty? 1
   enable-type-theory 1 error-to-string 1 interror 2 eval 1
   eval-kl 1 explode 1 external 1 fail-if 2 fail 0 fix 2
@@ -105,8 +105,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   hd 1 hdv 1 hdstr 1 head 1 if 3 integer? 1
   intern 1 identical 4 inferences 0 input 1 input+ 2 implementation 0
   intersection 2 internal 1 it 0 kill 0 language 0
-  length 1 lineread 1 load 1 < 2 <= 2 vector 1 macroexpand 1 map 2
-  mapcan 2 maxinferences 1 not 1 nth 2
+  length 1 limit 1 lineread 1 load 1 < 2 <= 2 vector 1 macroexpand 1 map 2
+  mapcan 2 maxinferences 1 nl 1 not 1 nth 2
   n->string 1 number? 1 occurs-check 1 occurrences 2 occurs-check 1
   open 2 optimise 1 or 2 os 0 package 3 package? 1
   port 0 porters 0 pos 2 print 1 profile 1 profile-results 1 pr 2


### PR DESCRIPTION
I noticed `str` and `vector?` were also not usable with `(function F)`, so I added them to the arity table.

I also noticed `open` and `close` do not work with `function`. I know there are different typing rules around streams, but it seems like you should be able to pass these as higher-order functions, like if you wanted to `(map (function close) StreamCollection)`. Add them too?