### PR TITLE
Removed duplicate of (define apply ...)

### DIFF
--- a/sources/backend.shen
+++ b/sources/backend.shen
@@ -84,13 +84,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (define apply
   F Arguments -> (let FSym (maplispsym F)
                    (trap-error
-                    ((protect APPLY) FSym Arguments)
-                    (/. E (analyse-application F FSym Arguments
-                                               (error-to-string E))))))
-
-(define apply
-  F Arguments -> (let FSym (maplispsym F)
-                   (trap-error
                     (apply-help FSym Arguments)
                     (/. E (analyse-application F FSym Arguments
                                                (error-to-string E))))))


### PR DESCRIPTION
Looks like a duplicate `define apply` - except the first one has `((protect APPLY) FSym Arguments)` and the second had `(apply-help FSym Arguments)`.

Is the first one vestigial code from an earlier version?