### PR TITLE
Basic dicts

### DIFF
--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (set *installing-kl* false)
 (set *history* [])
 (set *tc* false)
-(set *property-vector* (vector 20000))
+(set *property-vector* (dict 20000 (/. V N (hash V N))))
 (set *process-counter* 0)
 (set *varcounter* (vector 1000))
 (set *prologvectors* (vector 1000))

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -102,7 +102,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   eval-kl 1 explode 1 external 1 fail-if 2 fail 0 fix 2
   findall 5 freeze 1 fst 1 gensym 1 get 3
   get-time 1 address-> 3 <-address 2 <-vector 2 > 2 >= 2 = 2
-  hd 1 hdv 1 hdstr 1 head 1 if 3 integer? 1
+  hash 2 hd 1 hdv 1 hdstr 1 head 1 if 3 integer? 1
   intern 1 identical 4 inferences 0 input 1 input+ 2 implementation 0
   intersection 2 internal 1 it 0 kill 0 language 0
   length 1 limit 1 lineread 1 load 1 < 2 <= 2 vector 1 macroexpand 1 map 2

--- a/sources/sys.shen
+++ b/sources/sys.shen
@@ -375,10 +375,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                           (tl Result))))
 
 (define hash
-  S Limit -> (let Hash (mod (sum (map (/. X (string->n X)) (explode S))) Limit)
-               (if (= 0 Hash)
-                   1
-                   Hash)))
+  S Limit -> (mod (sum (map (/. X (string->n X)) (explode S))) Limit))
 
 (define mod
   N Div -> (modh N (multiples N [Div])))

--- a/sources/sys.shen
+++ b/sources/sys.shen
@@ -287,39 +287,92 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   _ X X -> X
   F _ X -> (fix-help F X (F X)))
 
+(define dict
+  Size HashFunc -> (let D (absvector (+ 3 Size))
+                        Tag (address-> D 0 dictionary)
+                        Capacity (address-> D 1 Size)
+                        Hash (address-> D 2 HashFunc)
+                        Fill (fillvector D 3 (+ 2 Size) [])
+                     D))
+
+(define dict?
+  X -> (and (absvector? X)
+            (trap-error
+             (= (<-address X 0) dictionary)
+             (/. E false))))
+
+(define dict-capacity
+  Dict -> (<-address Dict 1))
+
+(define dict-hash-function
+  Dict -> (<-address Dict 2))
+
+(define <-dict-slot
+  Dict N -> (<-address Dict (+ 3 N)))
+
+(define dict-slot->
+  Dict N Slot -> (address-> Dict (+ 3 N) Slot))
+
+(define set-key-entry-value
+  Key Value [] -> [[Key | Value]]
+  Key Value [[Key | _] | Slot] -> [[Key | Value] | Slot]
+  Key Value [Z | Slot] -> [Z | (set-key-entry-value Key Value Slot)])
+
+(define remove-key-entry-value
+  Key [] -> []
+  Key [[Key | _] | Slot] -> Slot
+  Key [Z | Slot] -> [Z | (remove-key-entry-value Key Slot)])
+
+(define dict->
+  Dict Key Value -> (let HashFunc (dict-hash-function Dict)
+                         Capacity (<-address Dict 1)
+                         N (HashFunc Key Capacity)
+                         Slot (<-dict-slot Dict N)
+                         Change (dict-slot-> Dict N (set-key-entry-value
+                                                     Key Value Slot))
+                      Value))
+
+(define <-dict
+  Dict Key -> (let HashFunc (dict-hash-function Dict)
+                   N (HashFunc Key (dict-capacity Dict))
+                   Slot (<-dict-slot Dict N)
+                   Result (assoc Key Slot)
+                (if (empty? Result)
+                    (error "value not found~%")
+                    (tl Result))))
+
+(define dict-rm
+  Dict Key -> (let HashFunc (dict-hash-function Dict)
+                   N (HashFunc Key (dict-capacity Dict))
+                   Slot (<-dict-slot Dict N)
+                   Change (dict-slot-> Dict N (remove-key-entry-value
+                                               Key Slot))
+                 Key))
+
 (define put
-  X Pointer Y Vector -> (let N (hash X (limit Vector))
-                             Entry (trap-error (<-vector Vector N) (/. E []))
-                             Change (vector-> Vector N (change-pointer-value
-                                                        X Pointer Y Entry))
-                           Y))
+  X Pointer Y Dict -> (let Curr (trap-error
+                                 (<-dict Dict X)
+                                 (/. E []))
+                           Added (set-key-entry-value Pointer Y Curr)
+                           Update (dict-> Dict X Added)
+                        Y))
 
 (define unput
-  X Pointer Vector -> (let N (hash X (limit Vector))
-                           Entry (trap-error (<-vector Vector N) (/. E []))
-                           Change (vector-> Vector N (remove-pointer
-                                                      X Pointer Entry))
-                         X))
-
-(define remove-pointer
-  X Pointer [] -> []
-  X Pointer [[[X Pointer] | _] | Entry] -> Entry
-  X Pointer [Z | Entry] -> [Z | (remove-pointer X Pointer Entry)])
-
-(define change-pointer-value
-  X Pointer Y [] -> [[[X Pointer] | Y]]
-  X Pointer Y [[[X Pointer] | _] | Entry] -> [[[X Pointer] | Y] | Entry]
-  X Pointer Y [Z | Entry] -> [Z | (change-pointer-value X Pointer Y Entry)])
+  X Pointer Dict -> (let Curr (trap-error
+                               (<-dict Dict X)
+                               (/. E []))
+                         Removed (remove-key-entry-value Pointer Curr)
+                         Update (dict-> Dict X Removed)
+                      X))
 
 (define get
-  X Pointer Vector -> (let N (hash X (limit Vector))
-                           Entry (trap-error
-                                  (<-vector Vector N)
-                                  (/. E (error "pointer not found~%")))
-                           Result (assoc [X Pointer] Entry)
-                        (if (empty? Result)
-                            (error "value not found~%")
-                            (tl Result))))
+  X Pointer Dict -> (let Entry (trap-error
+                                (<-dict Dict X)
+                                (/. E (error "pointer not found~%")))
+                         Result (assoc Pointer Entry)
+                      (if (empty? Result)
+                          (error "value not found~%")
+                          (tl Result))))
 
 (define hash
   S Limit -> (let Hash (mod (sum (map (/. X (string->n X)) (explode S))) Limit)


### PR DESCRIPTION
**DO NOT MERGE, SUBMITTED FOR REVIEW AND DISCUSSION**

Basic dictionaries, based no what was discussed in #20.

### Implemented:

- `(dict Capacity HashFunction)` constructor.
- `(dict-> Dict Key Value)` setter.
- `(<-dict Dict Key)` getter.
- `(dict-rm Dict Key)` deleter (not used internally).
- `(dict? X)` predicate.

### Not implemented:

- `(dict-fold Dict Func Init)` iterator (not needed internally).
- a printer for dictionaries.

### Reimplemented:

`put`, `get` and `unput` using these dictionaries. As far as the interface goes, nothing changed, but the structure is a bit different. In the previous implementation both the symbol and pointer were combined into a single key (kinda), in the new implementation the symbol is fetched from the global dictionary and then an assoc table (an alist) is used to associate the pointer with its value.

### Changed

`hash` now can return 0. In the previous implementation if 0 was to be returned, 1 was returned instead. The reason for this seems to be that property vectors where implemented on top of vectors which are only indexable with values greater than 0, but since thats not the case anymore this workaround can be removed.

### Notes:

- I tested these changes in the Scheme port, tests run fine, and I haven't noticed performance differences (that is, without overriding the dict implementation with native ones).
- None of these functions has been exposed by making them external to the `shen` namespace, it is out of scope as far as this PR goes.
- The `dict` constructor takes a custom hashing function as its second argument, many hash table implementations do this and it is an useful feature to have, not sure what others think of this (some platforms may not have this available? does it matter?).

Thoughts?