### PR TITLE
Handle overflows in prolog's complexity calculation function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Fixed
+- Handle integer overflows in prolog's complexity calculation function. Solves issues in ports with 32bit integers.
+
 ## [20.0] - 2017-04-23
 
 ### Added

--- a/sources/prolog.shen
+++ b/sources/prolog.shen
@@ -115,8 +115,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   [H :- B] -> [H :- (map (/. X (s-prolog_literal X)) B)])
 
 (define head_abstraction
-  [H :- B] -> [[H :- B]]  where (< (complexity_head H)
-                                   (value *maxcomplexity*))
+  [H :- B] -> [[H :- B]]  where (trap-error
+                                 (< (complexity_head H)
+                                    (value *maxcomplexity*))
+                                 (/. _ false))
   [[F | X] :- B] -> (let Terms (map (/. Y (gensym (protect V))) X)
                          XTerms (rcons_form (remove_modes X))
                          Literal [unify (cons_form Terms) XTerms]
@@ -124,20 +126,26 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                       [Clause]))
 
 (define complexity_head
-  [_ | Terms] -> (product (map (/. X (complexity X)) Terms)))
+  [_ | Terms] -> (safe-product (map (/. X (complexity X)) Terms)))
+
+\* Override in platforms where numbers can overflow *\
+(define safe-multiply
+  X Y -> (* X Y))
 
 (define complexity
   [mode [mode X Mode] _] -> (complexity [mode X Mode])
-  [mode [X | Y] +] -> (* 2 (complexity [mode X +]) (complexity [mode Y +]))
-  [mode [X | Y] -] -> (* (complexity [mode X -]) (complexity [mode Y -]))
+  [mode [X | Y] +] -> (safe-multiply 2 (safe-multiply (complexity [mode X +])
+                                                      (complexity [mode Y +])))
+  [mode [X | Y] -] -> (safe-multiply (complexity [mode X -])
+                                     (complexity [mode Y -]))
   [mode X _] -> 1	      where (variable? X)
   [mode _ +] -> 2
   [mode _ -] -> 1
   X -> (complexity [mode X +]))
 
-(define product
+(define safe-product
   [] -> 1
-  [X | Y] -> (* X (product Y)))
+  [X | Y] -> (safe-multiply X (safe-product Y)))
 
 (define s-prolog_literal
   [is X Y] -> [bind X (insert_deref Y)]


### PR DESCRIPTION
Based on PR #35 by @doublec, Fixes #34.

@doublec is this enough? What you have to override is `shen.safe-multiply`.