### PR TITLE
Command line access (implements #3)

### DIFF
--- a/doc/system-functions.md
+++ b/doc/system-functions.md
@@ -118,6 +118,20 @@ Closes a stream returning the empty list.
 Concatenates two strings.
 
 
+## command-line
+
+**Type:** **`--> (list string)`**
+
+Returns a list of command line fragments, with the first element being the program executable.
+
+Examples:
+
+```
+shen -> ["shen"]
+shen script.shen -> ["script.shen"]
+shen script.shen --flag -v arg1 arg2 -> ["script.shen" "--flag" "-v" "arg1" "arg2"]
+```
+
 ## compile
 
 **Type:** **`(A ==> B) --> A --> (A --> B) --> B`**

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -107,7 +107,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (initialise_arity_table
  [abort 0 absvector? 1 absvector 1 adjoin 2 and 2 append 2 arity 1
   assoc 2 boolean? 1 bound? 1 cd 1 close 1 compile 3 concat 2 cons 2 cons? 1
-  cn 2 declare 2 destroy 1 difference 2 do 2 element? 2 empty? 1
+  command-line 0 cn 2 declare 2 destroy 1 difference 2 do 2 element? 2 empty? 1
   enable-type-theory 1 error-to-string 1 interror 2 eval 1
   eval-kl 1 exit 1 explode 1 external 1 fail-if 2 fail 0 fix 2
   fold-left 3 fold-right 3 filter 2

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -92,6 +92,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     (set *sterror* (value *stoutput*))
     skip)
 
+(if (not (bound? *argv*))
+    (set *argv* ["shen"])
+    skip)
+
 (define initialise_arity_table
   [] -> []
   [F Arity | Table] -> (let DecArity (put F arity Arity)
@@ -149,7 +153,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (put (intern "shen") external-symbols
      [! } { --> <-- && : ; :- := _
       *language* *implementation* *stinput* *stoutput* *sterror*
-      *home-directory* *version*
+      *home-directory* *version* *argv*
       *maximum-print-sequence-size* *macros* *os* *release* *property-vector*
       *port* *porters* *hush*
       @v @p @s
@@ -185,6 +189,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       append and adjoin <-address <-address/or address-> absvector? absvector
       dict dict? dict-count dict-> <-dict/or <-dict dict-rm dict-fold
       dict-keys dict-values
+      command-line
       ])
 
 (define lambda-form-entry

--- a/sources/make.shen
+++ b/sources/make.shen
@@ -30,6 +30,8 @@
 (systemf read-char-code)
 (systemf read-file-as-charlist)
 (systemf *sterror*)
+(systemf *argv*)
+(systemf command-line)
 
 (define make
   -> (map (function make-file)

--- a/sources/sys.shen
+++ b/sources/sys.shen
@@ -598,6 +598,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (define sterror
   -> (value *sterror*))
 
+(define command-line
+  -> (value *argv*))
+
 (define string->symbol
   S -> (let Symbol (intern S)
          (if (symbol? Symbol)

--- a/sources/types.shen
+++ b/sources/types.shen
@@ -80,6 +80,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (declare cd [string --> string])
 (declare close [[stream A] --> [list B]])
 (declare cn [string --> [string --> string]])
+(declare command-line [--> [list string]])
 (declare compile [[A ==> B] --> [A --> [[A --> B] --> B]]])
 (declare cons? [A --> boolean])
 (declare destroy [[A --> B] --> symbol])


### PR DESCRIPTION
Ports can set `*argv*` to a list of command line fragments, otherwise it defaults to `["shen"]`.

In ports that support running scripts, the first element of the list shouldn't be the name of the interpreter executable, but the script, for example:

`shen-sbcl program.shen -v --output-file /tmp/test`

should be

`["program.shen" "-v" "--output-file" "/tmp/test"]`

and not

`["shen-sbcl" "program.shen" "-v" "--output-file" "/tmp/test"]`
