### PR TITLE
dict function signals an error when size is 0

### DIFF
--- a/sources/sys.shen
+++ b/sources/sys.shen
@@ -306,6 +306,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   F _ X -> (fix-help F X (F X)))
 
 (define dict
+  Size -> (error "invalid initial dict size: ~S" Size) where (< Size 1)
   Size -> (let D (absvector (+ 3 Size))
                Tag (address-> D 0 dictionary)
                Capacity (address-> D 1 Size)


### PR DESCRIPTION
Calling ``dict`` with argument ``0`` can result in a seemingly unrelated error signaled by the underlying platform (or maybe worse for less safe platforms). Signaling an error that describes the actual problem before starting to construct the dictionary seems better.