### PR TITLE
[DONT MERGE] Support for cons syntax in type signatures (via Mark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Added
+- Support for cons syntax in type signatures (via Mark)
+
 ## [21.0] - 2018-02-17
 
 ### Added

--- a/sources/core.shen
+++ b/sources/core.shen
@@ -52,9 +52,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   { <signature-help> } := (demodulate (curry-type <signature-help>));)
 
 (define curry-type
-  [A --> B --> | C] -> (curry-type [A --> [B --> | C]])
-  [A * B * | C] -> (curry-type [A * [B * | C]])
-  [X | Y] -> (map (/. Z (curry-type Z)) [X | Y])
+  A -> (active-cons (curry-type-h A)))
+
+(define active-cons
+  [X Bar Y] -> [(active-cons X) | (active-cons Y)]
+      where (= Bar bar!)
+  [X | Y] -> [(active-cons X) | (active-cons Y)]
+  X -> X)
+
+(define curry-type-h
+  [A --> B --> | C] -> (curry-type-h [A --> [B --> | C]])
+  [A * B * | C] -> (curry-type-h [A * [B * | C]])
+  [X | Y] -> (dotmap (/. Z (curry-type-h Z)) [X | Y])
   X -> X)
 
 (defcc <signature-help>

--- a/sources/t-star.shen
+++ b/sources/t-star.shen
@@ -208,14 +208,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (define ue
   [P X] -> [P X]	where (= P protect)
-  [X | Y] -> (map (/. Z (ue Z)) [X | Y])
+  [X | Y] -> (dotmap (/. Z (ue Z)) [X | Y])
   X -> (concat && X)        where (variable? X)
   X -> X)
 
 (define ue-sig
-  [X | Y] -> (map (/. Z (ue-sig Z)) [X | Y])
+  [X | Y] -> (dotmap (/. Z (ue-sig Z)) [X | Y])
   X -> (concat &&& X)        where (variable? X)
   X -> X)
+
+(define dotmap
+  _ [] -> []
+  F [X | Y] -> [(F X) | (dotmap F Y)]
+  F X -> (F X))
+
+(define dotwalk
+  F [X | Y] -> (F (dotmap (/. Z (dotwalk F Z)) [X | Y]))
+  F X -> (F X))
 
 (define ues
   X -> [X]   where (ue? X)

--- a/sources/types.shen
+++ b/sources/types.shen
@@ -47,7 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             F))
 
 (define demodulate
-  X -> (let Demod (walk (value *demodulation-function*) X)
+  X -> (let Demod (dotwalk (value *demodulation-function*) X)
          (if (= Demod X)
              X
              (demodulate Demod))))


### PR DESCRIPTION
Solves #57 

In addition to implementing the changes Mark described to me on an email, I had to add a new `dotwalk` function and change `demodulate` to use it instead of `walk`. Such change is not required to implement this fix in 19.2 (Mark's changes are enough in that case), but I haven't been able to figure out why yet.