### PR TITLE
[DONT MERGE] Special handling for let and lambda in derefs

### DIFF
--- a/sources/prolog.shen
+++ b/sources/prolog.shen
@@ -156,11 +156,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (define insert-deref
   V NPP -> [deref V NPP]	 where (variable? V)
+  [lambda V Body] NPP -> [lambda V (insert-deref Body NPP)]
+  [let V X Body] NPP -> [let V (insert-deref X NPP)
+                          (insert-deref Body NPP)]
   [X | Y] NPP -> [(insert-deref X NPP) | (insert-deref Y NPP)]
   X _ -> X)
 
 (define insert-lazyderef
   V NPP -> [lazyderef V NPP]	 where (variable? V)
+  [lambda V Body] NPP -> [lambda V (insert-lazyderef Body NPP)]
+  [let V X Body] NPP -> [let V (insert-lazyderef X NPP)
+                          (insert-lazyderef Body NPP)]
   [X | Y] NPP -> [(insert-lazyderef X NPP) | (insert-lazyderef Y NPP)]
   X _ -> X)
 


### PR DESCRIPTION
Special handling of `let` and `lambda` in prolog codo (related to #59, #64 and #65).

This implementation doesn't try to avoid allocating unnecessary prolog variables or to avoid unnecessary derefs.