### PR TITLE
Moving (reset) to the top of tests.shen

### DIFF
--- a/tests/tests.shen
+++ b/tests/tests.shen
@@ -1,3 +1,5 @@
+(reset)
+
 (maxinferences 10000000000)
 
 (report
@@ -263,5 +265,3 @@
  (tc +) true
  (load "TinyLispFunctions.txt") loaded
  (tc -) false)
-
-(reset) 


### PR DESCRIPTION
Prevented tests.shen from erasing the success/failure counts from the test run. `(reset)` happens at the beginning instead so each run is still clean if run multiple times.

After [this commit](https://github.com/rkoeninger/ShenScript/commit/7261c7a0c4a6fb4646aea9e5824f52e5bf0d2cfe) I figured it was time to do this.