### PR TITLE
Removed type# prefix from datatype names

### DIFF
--- a/sources/macros.shen
+++ b/sources/macros.shen
@@ -107,14 +107,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (define datatype-macro
   [datatype F | Rules]
-  -> (protect [process-datatype (intern-type F)
+  -> (protect [process-datatype F
                                 [compile [lambda X [<datatype-rules> X]]
                                          (rcons_form Rules)
                                          [function datatype-error]]])
   X -> X)
-
-(define intern-type
-  F -> (intern (cn "type#" (str F))))
 
 (define @s-macro
   [@s W X Y | Z] -> [@s W (@s-macro [@s X Y | Z])]

--- a/sources/sequent.shen
+++ b/sources/sequent.shen
@@ -220,29 +220,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   X -> X)
 
 (define preclude
-  Types -> (preclude-h (map (/. X (intern-type X)) Types)))
-
-(define preclude-h
   Types -> (let FilterDatatypes (set *datatypes*
                                      (difference (value *datatypes*) Types))
              (value *datatypes*)))
 
 (define include
-  Types -> (include-h (map (/. X (intern-type X)) Types)))
-
-(define include-h
   Types -> (let ValidTypes (intersection Types (value *alldatatypes*))
                 NewDatatypes (set *datatypes*
                                   (union ValidTypes (value *datatypes*)))
              (value *datatypes*)))
 
 (define preclude-all-but
-  Types -> (preclude-h (difference (value *alldatatypes*)
-                                   (map (/. X (intern-type X)) Types))))
+  Types -> (preclude (difference (value *alldatatypes*) Types)))
 
 (define include-all-but
-  Types -> (include-h (difference (value *alldatatypes*)
-                                  (map (/. X (intern-type X)) Types))))
+  Types -> (include (difference (value *alldatatypes*) Types)))
 
 (define synonyms-help
   [] -> (update-demodulation-function


### PR DESCRIPTION
Fixes #62 

@tizoc To resolve the linked issue, I just removed the `type#` prefix as I don't think it serves any functional purpose.

If there needs to be a qualifier, `-type` or `-datatype` could be added on the end instead so it won't get confused with package prefixes. (And if we go that way, could automatically add `-macro` to the end of macros to automatically provide disambiguation there, too)

I tried both the options described in the issue and neither worked.