### PR TITLE
Add customizable pattern matching extension (experimental)

### DIFF
--- a/doc/extensions/programmable-pattern-matching.md
+++ b/doc/extensions/programmable-pattern-matching.md
@@ -20,9 +20,9 @@ Supporting new patterns is done by the definition and registration of
 
 Pattern handling functions take as input 4 arguments:
 
-1. An object that represents a reference to the value being matched over. It is used when i.ding expressions that have to reference the object.
-2. A 1-place function that registers the expression that will be used to test if the value i.g matched over is of the kind of value the pattern can handle. The argument to this n.tion is a sexp that represents the expression to be used.
-3. A 2-place function that binds a vaiable in the pattern to an expression that will obtain s.value. It takes as input the variable and the expression it will be bound to.
+1. An object that represents a reference to the value being matched over. It is used when building expressions that have to reference the object.
+2. A 1-place function that registers the expression that will be used to test if the value being matched over is of the kind of value the pattern can handle. The argument to this function is a sexp that represents the expression to be used.
+3. A 2-place function that binds a vaiable in the pattern to an expression that will obtain its value. It takes as input the variable and the expression it will be bound to.
 4. The pattern that is being compiled.
 
 If the function cannot handle this pattern, it *MUST* return `(fail)`, so that another

--- a/doc/extensions/programmable-pattern-matching.md
+++ b/doc/extensions/programmable-pattern-matching.md
@@ -6,6 +6,15 @@ over in addition to what is supported natively.
 
 ## How to use
 
+Before using this extension, it has to be initialised (only once) by calling the 0-place `shen.x.programmable-pattern-matching.initialise` function:
+
+```shen
+\\ Ideally the port already comes with this extension loaded
+\\ and initialised, but if it is being use as a library,
+\\ then this step is required
+(shen.x.programmable-pattern-matching.initialise)
+```
+
 Supporting new patterns is done by the definition and registration of
 "pattern handler" functions.
 

--- a/doc/extensions/programmable-pattern-matching.md
+++ b/doc/extensions/programmable-pattern-matching.md
@@ -11,10 +11,10 @@ Supporting new patterns is done by the definition and registration of
 
 Pattern handling functions take as input 4 arguments:
 
-- 1) An object that represents a reference to the value being matched over. It is used when building expressions that have to reference the object.
-- 2) A 1-place function that registers the expression that will be used to test if the value being matched over is of the kind of value the pattern can handle. The argument to this function is a sexp that represents the expression to be used.
-- 3) A 2-place function that binds a vaiable in the pattern to an expression that will obtain its value. It takes as input the variable and the expression it will be bound to.
-- 4) The pattern that is being compiled.
+1. An object that represents a reference to the value being matched over. It is used when i.ding expressions that have to reference the object.
+2. A 1-place function that registers the expression that will be used to test if the value i.g matched over is of the kind of value the pattern can handle. The argument to this n.tion is a sexp that represents the expression to be used.
+3. A 2-place function that binds a vaiable in the pattern to an expression that will obtain s.value. It takes as input the variable and the expression it will be bound to.
+4. The pattern that is being compiled.
 
 If the function cannot handle this pattern, it *MUST* return `(fail)`, so that another
 pattern handler can be tried.

--- a/doc/extensions/programmable-pattern-matching.md
+++ b/doc/extensions/programmable-pattern-matching.md
@@ -1,0 +1,49 @@
+# Programmable pattern matching
+
+This extension provides hooks to augment Shen's compiler compilation of
+pattern matching in functions, allowing for new patterns to be matched
+over in addition to what is supported natively.
+
+## How to use
+
+Supporting new patterns is done by the definition and registration of
+"pattern handler" functions.
+
+Pattern handling functions take as input 4 arguments:
+
+- 1) An object that represents a reference to the value being matched over. It is used when building expressions that have to reference the object.
+- 2) A 1-place function that registers the expression that will be used to test if the value being matched over is of the kind of value the pattern can handle. The argument to this function is a sexp that represents the expression to be used.
+- 3) A 2-place function that binds a vaiable in the pattern to an expression that will obtain its value. It takes as input the variable and the expression it will be bound to.
+- 4) The pattern that is being compiled.
+
+If the function cannot handle this pattern, it *MUST* return `(fail)`, so that another
+pattern handler can be tried.
+
+The following example shows how pattern matching over lists and tuples could
+be implemented if the compiler didn't support it already:
+
+```shen
+(define cons-pattern-handler
+  \\ 1    2     3      4
+  Self AddTest Bind [cons H T]
+  -> (do (AddTest [cons? Self]) \\ (cons? X) checks if it is a cons
+         (Bind H [hd Self])     \\ (hd X) gets you H
+         (Bind T [tl Self]))    \\ (tl X) gets you T
+  \\ The function *MUST* return (fail) if it will not handle this pattern
+  _ _ _ _ -> (fail))
+
+(define tuple-pattern-handler
+  \\ 1     2     3      4
+  Self AddTest Bind [@p Fst Snd]
+  -> (do (AddTest [tuple? Self]) \\ (tuple? X) checks if it is a cons
+         (Bind Fst [fst Self])   \\ (fst X) gets you Fst
+         (Bind Snd [snd Self]))  \\ (snd X) gets you Snd
+  \\ The function *MUST* return (fail) if it will not handle this pattern
+  _ _ _ _ -> (fail))
+```
+
+### Notes:
+
+- It is not mandatory to bind all the variables in the pattern, some of the inputs may be used by the pattern handler to decide how such pattern should be compiled.
+- It is not mandatory to register a test expression, but in such cases matching of values with such patterns will always succeed. Such kind of patterns are only safe to use in typed functions.
+- The order of calling the `AddTest` and `Bind` functions doesn't matter.

--- a/doc/extensions/programmable-pattern-matching.md
+++ b/doc/extensions/programmable-pattern-matching.md
@@ -42,6 +42,20 @@ be implemented if the compiler didn't support it already:
   _ _ _ _ -> (fail))
 ```
 
+Once a pattern handler function has been defined, it can be registered and enabled by passing its name to the `shen.x.programmable-pattern-matching.register-handler` function:
+
+```shen
+(shen.x.programmable-pattern-matching.register-handler cons-pattern-handler)
+(shen.x.programmable-pattern-matching.register-handler tuple-pattern-handler)
+```
+
+A handler can be disabled by passing its name to the `shen.x.programmable-pattern-matching.unregister-handler` function:
+
+```shen
+(shen.x.programmable-pattern-matching.unregister-handler cons-pattern-handler)
+(shen.x.programmable-pattern-matching.unregister-handler tuple-pattern-handler)
+```
+
 ### Notes:
 
 - It is not mandatory to bind all the variables in the pattern, some of the inputs may be used by the pattern handler to decide how such pattern should be compiled.

--- a/extensions/extend-pattern-matching.shen
+++ b/extensions/extend-pattern-matching.shen
@@ -17,7 +17,7 @@
                                 done))
 
 (define compile-pattern
-  [Constructor | Args] -> (let Compile (/. X (<patterns> X))
+  [Constructor | Args] -> (let Compile (/. X (shen.<patterns> X))
                                Handler (/. E (error "failed to compile ~A" E))
                             [Constructor | (compile Compile Args Handler)]))
 

--- a/extensions/extend-pattern-matching.shen
+++ b/extensions/extend-pattern-matching.shen
@@ -1,0 +1,54 @@
+\\ Copyright (c) 2019 Bruno Deferrari.  All rights reserved.
+\\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
+
+\\ Documentation: docs/extensions/extend-pattern-matching.md
+
+(package shen.x.extend-pattern-matching []
+
+(define valid-constructor?
+  [X | Args] -> (= (trap-error (get X constructor-length) (/. _ -1))
+                   (length Args))
+  _ -> false)
+
+(define register-constructor
+  Head Predicate Accessors -> (do (put Head pattern-test Predicate)
+                                  (put Head accessors Accessors)
+                                  (put Head constructor-length (length Accessors))
+                                done))
+
+(define compile-pattern
+  [Constructor | Args] -> (let Compile (/. X (<patterns> X))
+                               Handler (/. E (error "failed to compile ~A" E))
+                            [Constructor | (compile Compile Args Handler)]))
+
+(define reduce
+  [[/. [Constructor | Args] Body] A]
+  -> (let MkTest (app-form-lambda (get Constructor pattern-test))
+          Test (MkTest A)
+          AccessorBuilders (map (/. S (app-form-lambda S)) (get Constructor accessors))
+          AddTest (shen.add_test Test)
+          Abstraction (build-abstraction Args (shen.ebr A [Constructor | Args] Body))
+          Application (build-application Abstraction AccessorBuilders A)
+       (shen.reduce_help Application)))
+
+(define app-form-lambda
+  Sym -> (/. A [Sym A]) where (symbol? Sym)
+  F -> F)
+
+(define build-abstraction
+  [] Body -> Body
+  [Arg | Args] Body -> [/. Arg (build-abstraction Args Body)])
+
+(define build-application
+  Abstraction [] _ -> Abstraction
+  Abstraction [AB | ABs] A -> [(build-application Abstraction ABs A) (AB A)])
+
+(define driver
+  "valid?" Arg -> (valid-constructor? Arg)
+  "compile" Arg -> (compile-pattern Arg)
+  "reduce" Arg -> (reduce Arg))
+
+(define initialise
+  -> (set shen.*custom-patterns-handler* (/. Msg Arg (driver Msg Arg))))
+
+)

--- a/extensions/extend-pattern-matching.shen
+++ b/extensions/extend-pattern-matching.shen
@@ -28,7 +28,7 @@
           AccessorBuilders (map (/. S (app-form-lambda S)) (get Constructor accessors))
           AddTest (shen.add_test Test)
           Abstraction (build-abstraction Args (shen.ebr A [Constructor | Args] Body))
-          Application (build-application Abstraction AccessorBuilders A)
+          Application (build-application Abstraction (reverse AccessorBuilders) A)
        (shen.reduce_help Application)))
 
 (define app-form-lambda

--- a/extensions/extend-pattern-matching.shen
+++ b/extensions/extend-pattern-matching.shen
@@ -53,9 +53,11 @@
           Is? (/. Expr (shen.add_test Expr))
           Assign (/. Var Expr (push SelectorStack (@p Var Expr)))
           Result (apply-pattern-handlers Handlers Ref Is? Assign [Constructor | Args])
-          Abstraction (shen.abstraction_build Args (shen.ebr Ref [Constructor | Args] Body))
-          SelectorBuilders (map (function snd) (reverse (pop-all SelectorStack)))
-          Application (shen.application_build SelectorBuilders Abstraction)
+          Vars+Sels (reverse (pop-all SelectorStack))
+          Vars (map (function fst) Vars+Sels)
+          Selectors (map (function snd) Vars+Sels)
+          Abstraction (shen.abstraction_build Vars (shen.ebr Ref [Constructor | Args] Body))
+          Application (shen.application_build Selectors Abstraction)
        (shen.reduce_help Application)))
 
 (define initialise

--- a/extensions/extend-pattern-matching.shen
+++ b/extensions/extend-pattern-matching.shen
@@ -32,6 +32,8 @@
        (shen.reduce_help Application)))
 
 (define app-form-lambda
+  true -> (/. _ true)
+  let -> (/. A A)
   Sym -> (/. A [Sym A]) where (symbol? Sym)
   F -> F)
 

--- a/extensions/programmable-pattern-matching.shen
+++ b/extensions/programmable-pattern-matching.shen
@@ -7,8 +7,8 @@
 
 (define apply-pattern-handlers
   [] _ _ _ _ -> (fail)
-  [Handler | _] Ref Is? Assign Expr <- (Handler Ref Is? Assign Expr)
-  [_ | Handlers] Ref Is? Assign Expr -> (apply-pattern-handlers Handlers Ref Is? Assign Expr))
+  [Handler | _] Self AddTest Bind Patt <- (Handler Self AddTest Bind Patt)
+  [_ | Handlers] Self AddTest Bind Patt -> (apply-pattern-handlers Handlers Self AddTest Bind Patt))
 
 (define make-stack
   -> (address-> (absvector 1) 0 []))
@@ -24,10 +24,10 @@
 (define compile-pattern
   Patt Handlers OnFail
   -> (let VarsStack (make-stack)
-          Ref (protect Self$$7907$$)
-          Is? (/. _ ignored)
-          Assign (/. Var _ (push VarsStack Var))
-          Result (apply-pattern-handlers Handlers Ref Is? Assign Patt)
+          Self (protect Self$$7907$$)
+          AddTest (/. _ ignored)
+          Bind (/. Var _ (push VarsStack Var))
+          Result (apply-pattern-handlers Handlers Self AddTest Bind Patt)
        (if (= Result (fail))
            (thaw OnFail)
            (compile-pattern-h Patt (reverse (pop-all VarsStack))))))
@@ -43,15 +43,15 @@
        [Constructor | NewArgs]))
 
 (define reduce
-  [[/. [Constructor | Args] Body] Ref] Handlers
+  [[/. [Constructor | Args] Body] Self] Handlers
   -> (let SelectorStack (make-stack)
-          Is? (/. Expr (shen.add_test Expr))
-          Assign (/. Var Expr (push SelectorStack (@p Var Expr)))
-          Result (apply-pattern-handlers Handlers Ref Is? Assign [Constructor | Args])
+          AddTest (/. Expr (shen.add_test Expr))
+          Bind (/. Var Expr (push SelectorStack (@p Var Expr)))
+          Result (apply-pattern-handlers Handlers Self AddTest Bind [Constructor | Args])
           Vars+Sels (reverse (pop-all SelectorStack))
           Vars (map (function fst) Vars+Sels)
           Selectors (map (function snd) Vars+Sels)
-          Abstraction (shen.abstraction_build Vars (shen.ebr Ref [Constructor | Args] Body))
+          Abstraction (shen.abstraction_build Vars (shen.ebr Self [Constructor | Args] Body))
           Application (shen.application_build Selectors Abstraction)
        (shen.reduce_help Application)))
 

--- a/extensions/programmable-pattern-matching.shen
+++ b/extensions/programmable-pattern-matching.shen
@@ -63,9 +63,10 @@
          done))
 
 (define register-handler
-  F -> skip where (element? F (value *pattern-handlers-reg*))
+  F -> F where (element? F (value *pattern-handlers-reg*))
   F -> (do (set *pattern-handlers-reg* [F | (value *pattern-handlers-reg*)])
-           (set *pattern-handlers* [(function F) | (value *pattern-handlers*)])))
+           (set *pattern-handlers* [(function F) | (value *pattern-handlers*)])
+           F))
 
 (define findpos
   Sym L -> (trap-error (shen.findpos Sym L)

--- a/extensions/programmable-pattern-matching.shen
+++ b/extensions/programmable-pattern-matching.shen
@@ -1,14 +1,9 @@
 \\ Copyright (c) 2019 Bruno Deferrari.  All rights reserved.
 \\ BSD 3-Clause License: http://opensource.org/licenses/BSD-3-Clause
 
-\\ Documentation: docs/extensions/extend-pattern-matching.md
+\\ Documentation: docs/extensions/programmable-pattern-matching.md
 
-(package shen.x.extend-pattern-matching []
-
-(define register-pattern-handler
-  F -> skip where (element? F (value *pattern-handlers-reg*))
-  F -> (do (set *pattern-handlers-reg* [F | (value *pattern-handlers-reg*)])
-           (set *pattern-handlers* [(function F) | (value *pattern-handlers*)])))
+(package shen.x.programmable-pattern-matching []
 
 (define apply-pattern-handlers
   [] _ _ _ _ -> (fail)
@@ -66,5 +61,21 @@
          (set *pattern-handlers* [])
          (set *pattern-handlers-reg* [])
          done))
+
+(define register-handler
+  F -> skip where (element? F (value *pattern-handlers-reg*))
+  F -> (do (set *pattern-handlers-reg* [F | (value *pattern-handlers-reg*)])
+           (set *pattern-handlers* [(function F) | (value *pattern-handlers*)])))
+
+(define findpos
+  Sym L -> (trap-error (shen.findpos Sym L)
+                       (/. _ (error "~A is not a pattern handler~%" F))))
+
+(define unregister-handler
+  F -> (let Reg (value *pattern-handlers-reg*)
+            Pos (findpos F Reg))
+            RemoveReg (set *pattern-handlers-reg* (remove F Reg))
+            RemoveFun (set *pattern-handlers* (shen.remove-nth Pos (value *pattern-handlers*)))
+         F)
 
 )

--- a/sources/core.shen
+++ b/sources/core.shen
@@ -88,11 +88,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   X -> false  where (= X (fail))
   _ -> true)
 
-(define custom-pattern-handler
-  Msg Arg -> (let F (value *custom-patterns-handler*)
-               (if (= F false)
-                   false
-                   (F Msg Arg))))
+(define custom-pattern-compiler
+  Arg OnFail -> ((value *custom-pattern-compiler*) Arg OnFail))
+
+(define custom-pattern-reducer
+  Arg -> ((value *custom-pattern-reducer*) Arg))
 
 (defcc <patterns>
   <pattern> <patterns> := [<pattern> | <patterns>];
@@ -104,9 +104,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   [@v <pattern1> <pattern2>] := [@v <pattern1> <pattern2>];
   [@s <pattern1> <pattern2>] := [@s <pattern1> <pattern2>];
   [vector 0] := [vector 0];
-  Constructor := (custom-pattern-handler "compile" Constructor)
-      where (custom-pattern-handler "valid?" Constructor);
-  X := (constructor-error X) 	where (cons? X);
+  X := (custom-pattern-compiler X (freeze (constructor-error X)))
+      where (cons? X);
   <simple_pattern> := <simple_pattern>;)
 
 (define constructor-error
@@ -342,9 +341,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
               Application [[Abstraction [pos A 0]] [tlstr A]]
            (reduce_help Application)))
   [[/. [Constructor | Args] Body] A]
-  -> (custom-pattern-handler "reduce"
-       [[/. [Constructor | Args] Body] A])
-      where (custom-pattern-handler "valid?" [Constructor | Args])
+  -> (custom-pattern-reducer [[/. [Constructor | Args] Body] A])
   [[/. X Z] A]
   -> (do (add_test [= X A])
          (reduce_help Z))  where (not (variable? X))

--- a/sources/core.shen
+++ b/sources/core.shen
@@ -88,6 +88,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   X -> false  where (= X (fail))
   _ -> true)
 
+(define custom-pattern-handler
+  Msg Arg -> (let F (value *custom-patterns-handler*)
+               (if (= F false)
+                   false
+                   (F Msg Arg))))
+
 (defcc <patterns>
   <pattern> <patterns> := [<pattern> | <patterns>];
   <e> := [];)
@@ -98,6 +104,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   [@v <pattern1> <pattern2>] := [@v <pattern1> <pattern2>];
   [@s <pattern1> <pattern2>] := [@s <pattern1> <pattern2>];
   [vector 0] := [vector 0];
+  Constructor := (custom-pattern-handler "compile" Constructor)
+      where (custom-pattern-handler "valid?" Constructor)
   X := (constructor-error X) 	where (cons? X);
   <simple_pattern> := <simple_pattern>;)
 
@@ -333,6 +341,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
          (let Abstraction [/. X [/. Y (ebr A [@s X Y] Z)]]
               Application [[Abstraction [pos A 0]] [tlstr A]]
            (reduce_help Application)))
+  [[/. [Constructor | Args] Body] A]
+  -> (custom-pattern-handler "reduce"
+       [[/. [Constructor | Args] Body] A])
+      where (custom-pattern-handler "valid?" [Constructor | Args])
   [[/. X Z] A]
   -> (do (add_test [= X A])
          (reduce_help Z))  where (not (variable? X))

--- a/sources/core.shen
+++ b/sources/core.shen
@@ -105,7 +105,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   [@s <pattern1> <pattern2>] := [@s <pattern1> <pattern2>];
   [vector 0] := [vector 0];
   Constructor := (custom-pattern-handler "compile" Constructor)
-      where (custom-pattern-handler "valid?" Constructor)
+      where (custom-pattern-handler "valid?" Constructor);
   X := (constructor-error X) 	where (cons? X);
   <simple_pattern> := <simple_pattern>;)
 

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (set *varcounter* (vector 10000))
 (set *prologvectors* (vector 10000))
 (set *demodulation-function* (/. X X))
+(set *custom-patterns-handler* false)
 (set *macroreg* [timer-macro cases-macro abs-macro put/get-macro
                  compile-macro datatype-macro let-macro assoc-macro
                  make-string-macro output-macro input-macro error-macro

--- a/sources/declarations.shen
+++ b/sources/declarations.shen
@@ -37,7 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (set *varcounter* (vector 10000))
 (set *prologvectors* (vector 10000))
 (set *demodulation-function* (/. X X))
-(set *custom-patterns-handler* false)
+(set *custom-pattern-compiler* (/. Arg OnFail (thaw OnFail)))
+(set *custom-pattern-reducer* (/. Arg Arg))
 (set *macroreg* [timer-macro cases-macro abs-macro put/get-macro
                  compile-macro datatype-macro let-macro assoc-macro
                  make-string-macro output-macro input-macro error-macro

--- a/sources/t-star.shen
+++ b/sources/t-star.shen
@@ -256,7 +256,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (define patthyps
   [] _ Hyp -> Hyp
-  [Pattern | Patterns] [A --> B] Hyp -> (adjoin [Pattern : A] (patthyps Patterns B Hyp)))
+  [Pattern | Patterns] [A --> B] Hyp -> (adjoin [(curry Pattern) : A] (patthyps Patterns B Hyp)))
 
 (define result-type
   [] [--> A] -> A
@@ -266,7 +266,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (defprolog t*-patterns
   (mode [] -) _ _ <--;
   (mode [Pattern | Patterns] -) (mode [A --> B] -) Hyp
-    <-- (t* [Pattern : A] Hyp)
+    <-- (t* [(curry Pattern) : A] Hyp)
         (t*-patterns Patterns B Hyp);)
 
 (defprolog t*-action


### PR DESCRIPTION
While this works in its current form, this is experimental and a work in progress.

Example:

Given this "maybe" type (functions omitted):

```shen
(datatype maybe
  X : A;
  ________________
  X : (mode (maybe A) -);

  X : (maybe A);
  ________________
  (some? X) : verified >> X : A;)

(datatype pattern-matching
  ______________
  (@none) : (maybe A);

  X : A;
  ==============
  (@some X) : (maybe A);)
```

```
Shen, copyright (C) 2010-2015 Mark Tarver
www.shenlanguage.org, Shen 22.2
running under Scheme, implementation: chez-scheme
port 0.22 ported by Bruno Deferrari


(0-) (shen.x.extend-pattern-matching.register-constructor @none none? [])
shen.done

(1-) (shen.x.extend-pattern-matching.register-constructor @some some? [(/. A A)])
shen.done

(2-) (tc +)
true

(3+) (load "maybe.shen")

maybe.maybe-internal#type : symbol
maybe.maybe#type : symbol
maybe.pattern-match#type : symbol
@none : (--> (maybe A))
@some : (A --> (maybe A))
none? : ((maybe A) --> boolean)
some? : ((maybe A) --> boolean)
[maybe.pattern-match#type maybe.maybe#type] : (list symbol)
run time: 0.05879399999999996 secs

typechecked in 420 inferences
loaded : symbol

(4+) (define get-or
  { (maybe A) --> (lazy A) --> A }
  (@some X) _ -> X
  _ Default -> (thaw Default))
get-or : ((maybe A) --> ((lazy A) --> A))

(5+) (get-or 10 (freeze 0))
10 : number

(6+) (get-or (@none) (freeze 0))
0 : number

(7+) (ps get-or)
[defun get-or [V677 V678] [cond [[some? V677] V677] [true [thaw V678]]]] : (list unit)
```

The `register-constructor` function takes as inputs:

- The name of the function that is used as a constructor (in this example @some and @none)
- A predicate to check if the value matches that constructor (either a symbol, or a lambda that takes as input a variable and returns an expression)
- A list of accessors (either lambdas that take a variable as input and return an expression, or a symbol that matches the name of the accessor). The length of this list has to match the length of the arguments consumed by the constructor.