### PR TITLE
Hooks on factorise-defun extension to define custom selector optimizations

### DIFF
--- a/doc/extensions/factorise-defun.md
+++ b/doc/extensions/factorise-defun.md
@@ -66,6 +66,26 @@ and
 
 The port has to convert these constructs to something suitable for the underlying platform.
 
+### Optimization of custom selectors
+
+If the `programmable-pattern-matching` extension is used to add new patterns that generate selectors different from the ones used by core datatypes, it is possible to extend the factoriser to make it handle those new selectors by registering a selector handling function by passing its name to the `shen.x.factorise-defun.register-selector-handler` function.
+
+A selector handling function needs to match an expression that recognizes the value on which the selectors work, and return a list containing expressions for all the relevant selectors.
+
+```shen
+(define mycons-selector-handler
+  [mycons? X] -> [[myhd X] [mytl X]]
+  _ -> (fail))
+
+(shen.x.factorise-defun.register-selector-handler mycons-selector-handler)
+```
+
+Handlers can be removed with the `shen.x.factorise-defun.deregister-selector-handler` function:
+
+```shen
+(shen.x.factorise-defun.deregister-selector-handler mycons-selector-handler)
+```
+
 ## Example
 
 The following function:

--- a/extensions/factorise-defun.shen
+++ b/extensions/factorise-defun.shen
@@ -136,8 +136,7 @@
 
 (define exp-var
   [SelF Exp] -> (concat/ (exp-var Exp) SelF)
-      where (element? SelF [hd tl hdv tlv fst snd tlstr])
-  [hdstr Exp] -> (concat/ (exp-var Exp) hdstr)
+      where (element? SelF [hd tl hdv tlv fst snd hdstr tlstr])
   Var -> Var)
 
 (define optimize-selectors

--- a/extensions/factorise-defun.shen
+++ b/extensions/factorise-defun.shen
@@ -145,8 +145,8 @@
 (define test->selectors
   [cons? X] -> [[hd X] [tl X]]
   [tuple? X] -> [[fst X] [snd X]]
-  [string? X] -> [[hdstr X] [tlstr X]]
-  [vector? X] -> [[hdv X] [tlv X]]
+  [+string? X] -> [[hdstr X] [tlstr X]]
+  [+vector? X] -> [[hdv X] [tlv X]]
   _ -> [])
 
 (define bind-repeating-selectors

--- a/extensions/factorise-defun.shen
+++ b/extensions/factorise-defun.shen
@@ -150,8 +150,8 @@
   _ -> [])
 
 (define bind-repeating-selectors
-  [SelA SelB] Body -> (bind-selector SelA (bind-selector SelB Body))
-   _ Body -> Body)
+  [Sel | Rest] Body -> (bind-selector Sel (bind-repeating-selectors Rest Body))
+  [] Body -> Body)
 
 (define bind-selector
   Sel Body -> (let Var (exp-var Sel)

--- a/extensions/factorise-defun.shen
+++ b/extensions/factorise-defun.shen
@@ -145,8 +145,8 @@
 (define test->selectors
   [cons? X] -> [[hd X] [tl X]]
   [tuple? X] -> [[fst X] [snd X]]
-  [+string? X] -> [[hdstr X] [tlstr X]]
-  [+vector? X] -> [[hdv X] [tlv X]]
+  [shen.+string? X] -> [[hdstr X] [tlstr X]]
+  [shen.+vector? X] -> [[hdv X] [tlv X]]
   _ -> [])
 
 (define bind-repeating-selectors


### PR DESCRIPTION
**WIP**

Adds hooks in the `factorise-defun` extension to extend the way selectors are optimized so that the pattern matching customization extension can take advantage of this optimization too.