### PR TITLE
Remove `native-hash` and its use in `dict->`

### DIFF
--- a/sources/dict.shen
+++ b/sources/dict.shen
@@ -3,9 +3,6 @@
 
 (package shen []
 
-(define native-hash
-  S Limit -> (mod (hashkey S) Limit))
-
 (define dict
   Size -> (error "invalid initial dict size: ~S" Size) where (< Size 1)
   Size -> (let D (absvector (+ 3 Size))
@@ -42,7 +39,7 @@
                                  Dict (+ Diff (dict-count Dict)))))
 
 (define dict->
-  Dict Key Value -> (let N (native-hash Key (dict-capacity Dict))
+  Dict Key Value -> (let N (hash Key (dict-capacity Dict))
                          Bucket (<-dict-bucket Dict N)
                          NewBucket (assoc-set Key Value Bucket)
                          Change (dict-bucket-> Dict N NewBucket)


### PR DESCRIPTION
Using ShenSharp and the previous commit's source release, I observed a test failure after loading mutual.shen. Upon inspection, `odd*?` proved impossible to define in REPL. Digging, I realized that I had found a bad interaction with `native-hash` in `dict->`. The other dict functions use `hash`, which never returns 0. In my ShenSharp environment, `odd*?` hashes to 0 using the default property vector length.

```
(12-) (shen.native-hash odd*? (shen.dict-capacity (value *property-vector*)))
0

(13-) (shen.native-hash even*? (shen.dict-capacity (value *property-vector*)))
1080

(16-) (hash odd*? (shen.dict-capacity (value *property-vector*)))
1

(17-) (hash even*? (shen.dict-capacity (value *property-vector*)))
1080
```

Thus, the test suite would necessarily fail.

`native-hash` appears to have been re-added, so with the removal of its use I have also deleted the function.